### PR TITLE
#169 [bug] Change Nickname Dialog Bug Fix

### DIFF
--- a/app/src/main/java/how/about/it/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/how/about/it/viewmodel/ProfileViewModel.kt
@@ -6,7 +6,7 @@ import how.about.it.repository.ProfileRepository
 
 class ProfileViewModel() : ViewModel() {
 
-    val duplicateCheckNicknameSuccess = MutableLiveData<Boolean>()
+    val duplicateCheckNicknameSuccess = MutableLiveData<Boolean?>()
     val duplicateCheckNicknameFailedMessage = MutableLiveData<String?>()
 
     private val profileRepository = ProfileRepository()


### PR DESCRIPTION
- [x] 닉네임 8글자 및 공백 제한 설정
- [x] 닉네임 중복확인시 Dialog 중복 실행 버그
- [x] 닉네임 변경 후 다시 프로필 변경 Fragment로 진입 시 직전에 실행된 Dialog가 다시 실행되는 버그

resolved: #169