### PR TITLE
#235 [bug] Set HideKeyboard in LoginFragment

### DIFF
--- a/app/src/main/java/how/about/it/view/login/EmailLoginFragment.kt
+++ b/app/src/main/java/how/about/it/view/login/EmailLoginFragment.kt
@@ -1,6 +1,7 @@
 package how.about.it.view.login
 
 import android.app.AlertDialog
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
@@ -10,6 +11,7 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import android.widget.Button
 import android.widget.TextView
 import android.widget.Toast
@@ -46,6 +48,8 @@ class EmailLoginFragment : Fragment() {
         val mDialogView = LayoutInflater.from(requireContext()).inflate(R.layout.dialog_default_confirm, null)
         val mBuilder = AlertDialog.Builder(requireContext()).setView(mDialogView)
         val mAlertDialog = mBuilder.create()
+
+        setKeyboardHide()
 
         binding.btnLoginEmail.setOnClickListener {
             if (binding.etLoginEmailId.text.isNullOrBlank() || binding.etLoginEmailPassword.text.isNullOrBlank()) {
@@ -128,6 +132,14 @@ class EmailLoginFragment : Fragment() {
     fun deactiveButtonLoginEmail() {
         binding.btnLoginEmail.setBackground(ContextCompat.getDrawable(requireContext(), R.drawable.button_default_disable))
         binding.btnLoginEmail.setTextColor(resources.getColorStateList(R.color.bluegray600_626670, context?.theme))
+    }
+
+    private fun setKeyboardHide() {
+        binding.root.setOnTouchListener { _, event ->
+            val inputMethodManager : InputMethodManager = activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            inputMethodManager.hideSoftInputFromWindow(activity?.currentFocus?.windowToken, 0)
+            true
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/how/about/it/view/login/EmailPasswordResetFragment.kt
+++ b/app/src/main/java/how/about/it/view/login/EmailPasswordResetFragment.kt
@@ -1,6 +1,7 @@
 package how.about.it.view.login
 
 import android.app.AlertDialog
+import android.content.Context
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
@@ -9,6 +10,8 @@ import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
 import android.widget.Button
 import android.widget.TextView
 import android.widget.Toast
@@ -36,6 +39,9 @@ class EmailPasswordResetFragment : Fragment() {
         (activity as LoginActivity).setSupportActionBar(binding.toolbarLoginBoard.toolbarBoard)
         (activity as LoginActivity).supportActionBar?.setDisplayShowTitleEnabled(false)
         showBackButton()
+
+        setKeyboardDoneClick()
+        setKeyboardHide()
 
         binding.btnResetEmail.setOnClickListener {
             if(binding.etLoginEmailId.text.isNullOrBlank()) {
@@ -111,6 +117,26 @@ class EmailPasswordResetFragment : Fragment() {
     fun deactiveButtonResetPassword() {
         binding.btnResetEmail.setBackground(ContextCompat.getDrawable(requireContext(), R.drawable.button_default_disable))
         binding.btnResetEmail.setTextColor(resources.getColorStateList(R.color.bluegray600_626670, context?.theme))
+    }
+
+    private fun setKeyboardDoneClick() {
+        binding.etLoginEmailId.setOnEditorActionListener { _, actionId, event ->
+            var handled = false
+
+            if (actionId == EditorInfo.IME_ACTION_DONE) {
+                val inputMethodManager = activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+                inputMethodManager.hideSoftInputFromWindow(binding.etLoginEmailId.windowToken, 0)
+                handled = true
+            }
+            handled
+        }
+    }
+    private fun setKeyboardHide() {
+        binding.root.setOnTouchListener { _, event ->
+            val inputMethodManager : InputMethodManager = activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            inputMethodManager.hideSoftInputFromWindow(activity?.currentFocus?.windowToken, 0)
+            true
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/res/layout/fragment_email_login.xml
+++ b/app/src/main/res/layout/fragment_email_login.xml
@@ -46,6 +46,8 @@
             android:hint="@string/hint_email"
             android:textColorHint="@color/bluegray600_626670"
             android:textColor="@color/bluegray200_E1E3E8"
+            android:singleLine="true"
+            android:imeOptions="actionNext"
             android:backgroundTint="@color/bluegray300_CBCFD6"
             />
         <androidx.appcompat.widget.AppCompatImageButton

--- a/app/src/main/res/layout/fragment_email_password_reset.xml
+++ b/app/src/main/res/layout/fragment_email_password_reset.xml
@@ -57,6 +57,8 @@
             android:hint="@string/hint_email"
             android:textColorHint="@color/bluegray600_626670"
             android:textColor="@color/bluegray200_E1E3E8"
+            android:singleLine="true"
+            android:imeOptions="actionDone"
             android:backgroundTint="@color/bluegray300_CBCFD6"
             />
         <androidx.appcompat.widget.AppCompatImageButton


### PR DESCRIPTION
- [x] 이메일 계정 로그인 화면에서, 이메일 계정 입력시 singline 설정
- [x] 이메일 계정 로그인 화면에서, 이메일 계정 소프트 키보드 다음 버튼 노출 및 클릭 시 비밀번호 입력창으로 이동하도록 적용
- [x] 비밀번호 초기화 화면에서 이메일 계정 입력창 singline 적용 및 소프트키보드 이외 영역 클릭 시 키보드 숨김 적용

resolved: #235