### PR TITLE
#249 [layout] Modify Login Message

### DIFF
--- a/app/src/main/java/how/about/it/view/login/LoginActivity.kt
+++ b/app/src/main/java/how/about/it/view/login/LoginActivity.kt
@@ -66,7 +66,7 @@ class LoginActivity : ToolbarActivity() {
             mGoogleSignInClient.silentSignIn().addOnCompleteListener(this, OnCompleteListener<GoogleSignInAccount?> { task -> handleSignInResult(task) })
         }
 
-        loginViewBinding.btnGoogleLogin.setOnClickListener {
+        loginViewBinding.layoutGoogleLogin.setOnClickListener {
             GoogleAccountSignIn()
         }
         loginViewBinding.btnEmailLogin.setOnClickListener {
@@ -126,7 +126,7 @@ class LoginActivity : ToolbarActivity() {
     public fun EmailAccountSignUp() {
         // 액티비티 버튼이 눌리지 않도록 임시조치
         loginViewBinding.btnEmailLogin.isEnabled = false
-        loginViewBinding.btnGoogleLogin.isEnabled = false
+        loginViewBinding.layoutGoogleLogin.isEnabled = false
         val emailSignupSetIDFragment = EmailSignupSetIDFragment()
         val transaction = supportFragmentManager.beginTransaction()
         transaction.add(R.id.frameLayout_login_signup_fragment, emailSignupSetIDFragment)
@@ -143,7 +143,7 @@ class LoginActivity : ToolbarActivity() {
     private fun EmailAccountSignIn() {
         // 액티비티 버튼이 눌리지 않도록 임시조치
         loginViewBinding.btnEmailLogin.isEnabled = false
-        loginViewBinding.btnGoogleLogin.isEnabled = false
+        loginViewBinding.layoutGoogleLogin.isEnabled = false
         // Email로 로그인하는 Fragment로 이동
         val emailLoginFragment = EmailLoginFragment()
         val transaction = supportFragmentManager.beginTransaction()

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -19,25 +19,57 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toTopOf="@id/btn_google_login"
+            app:layout_constraintBottom_toTopOf="@id/layout_google_login"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
             app:srcCompat="@drawable/ic_logo_moomool"
             />
 
-        <androidx.appcompat.widget.AppCompatImageButton
-            android:id="@+id/btn_google_login"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_google_login"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintBottom_toTopOf="@id/btn_email_login"
-            android:src="@drawable/button_login_google_img"
-            android:layout_marginLeft="20dp"
-            android:layout_marginRight="20dp"
+            android:layout_marginHorizontal="20dp"
             android:layout_marginBottom="12dp"
+            android:paddingVertical="12dp"
             android:background="@drawable/button_login_google"
-            />
+            >
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                >
+                <ImageView
+                    android:id="@+id/img_login_google_logo"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintRight_toLeftOf="@id/tv_google_login"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    android:layout_marginRight="7dp"
+                    android:background="@drawable/ic_logo_google"
+                    />
+                <TextView
+                    android:id="@+id/tv_google_login"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintLeft_toRightOf="@+id/img_login_google_logo"
+                    app:layout_constraintRight_toRightOf="parent"
+                    android:text="@string/login_google"
+                    android:textColor="@color/bluegray700_4D535E"
+                    android:textSize="16sp"
+                    />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btn_email_login"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,7 +31,8 @@
 
     <!-- Login -->
     <string name="login">로그인</string>
-    <string name="login_email">이메일로 시작하기</string>
+    <string name="login_google">구글 계정으로 로그인</string>
+    <string name="login_email">이메일 계정으로 로그인</string>
     <string name="signup_guide_message">무물이 처음이신가요? <u>회원가입</u></string>
     <string name="login_fail_dialog_title">로그인 실패!</string>
     <string name="login_fail_dialog_description">아이디 혹은 비밀번호가 일치하지 않아요!</string>


### PR DESCRIPTION
- [x] 최초 로그인 진행시 "~로 시작하기" 라는 멘트로 인하여 로그인 혼동 발생으로 "~계정으로 로그인" 으로 메시지 수정
- [x] 구글 계정 로그인 버튼 기존 이미지 버튼에서 텍스트로 보여질 수 있도록 수정

resolved: #249