### PR TITLE
#277 [feature] Send Reset Password E-mail

### DIFF
--- a/app/src/main/java/com/moo/mool/model/RequestResetPassword.kt
+++ b/app/src/main/java/com/moo/mool/model/RequestResetPassword.kt
@@ -1,0 +1,8 @@
+package com.moo.mool.model
+
+import com.google.gson.annotations.SerializedName
+
+data class RequestResetPassword(
+    @SerializedName("email")
+    var email : String?= null
+)

--- a/app/src/main/java/com/moo/mool/network/RequestInterface.kt
+++ b/app/src/main/java/com/moo/mool/network/RequestInterface.kt
@@ -24,15 +24,18 @@ interface RequestInterface {
     @PUT("/api/v1/member/token")
     fun requestTokenRefresh(@Body body : RequestTokenRefresh) : Call<ResponseTokenRefresh>
 
-    @Multipart
-    @POST("/api/v1/posts")
-    fun requestUploadPost(@Part("title") title: String, @Part("content") content: String, @Part file: MultipartBody.Part?) : Call<ResponseUploadPost>
-
     @GET("/api/v1/member/exists/{email}/email")
     fun requestDuplicateCheckEmail(@Path("email") email : String) : Call<String>
 
     @GET("/api/v1/member/exists/{name}/name")
     fun requestDuplicateCheckNickname(@Path("name") name : String) : Call<String>
+
+    @PUT("/api/v1/member/reset")
+    fun requestResetPassword(@Body body : RequestResetPassword) : Call<String>
+
+    @Multipart
+    @POST("/api/v1/posts")
+    fun requestUploadPost(@Part("title") title: String, @Part("content") content: String, @Part file: MultipartBody.Part?) : Call<ResponseUploadPost>
 
     @GET("/api/v1/notice")
     fun requestNoticeList() : Call<ResponseNotice>

--- a/app/src/main/java/com/moo/mool/repository/LoginRepository.kt
+++ b/app/src/main/java/com/moo/mool/repository/LoginRepository.kt
@@ -3,10 +3,7 @@ package com.moo.mool.repository
 import android.content.Context
 import com.moo.mool.database.SharedManager
 import com.moo.mool.database.User
-import com.moo.mool.model.RequestLogin
-import com.moo.mool.model.RequestTokenRefresh
-import com.moo.mool.model.ResponseLogin
-import com.moo.mool.model.ResponseTokenRefresh
+import com.moo.mool.model.*
 import com.moo.mool.network.RequestToServer
 import org.json.JSONObject
 import retrofit2.Call
@@ -91,6 +88,28 @@ class LoginRepository(private val context: Context) {
                         loginCallBack.onError(e.message)
                     }
                 }
+            }
+        })
+    }
+
+    fun resetPassword(email: String, loginCallBack: LoginCallBack) {
+        RequestToServer.service.requestResetPassword(
+            RequestResetPassword(email)
+        ).enqueue(object : Callback<String> {
+            override fun onResponse(call: Call<String>, response: Response<String>) {
+                if(response.isSuccessful) {
+                    loginCallBack.onSuccess()
+                } else {
+                    try {
+                        val jObjError = JSONObject(response.errorBody()!!.string())
+                        loginCallBack.onError(jObjError.getString("user_msg"))
+                    } catch (e: Exception) {
+                        loginCallBack.onError(e.message)
+                    }
+                }
+            }
+            override fun onFailure(call: Call<String>, t: Throwable) {
+                loginCallBack.onError(t.localizedMessage)
             }
         })
     }

--- a/app/src/main/java/com/moo/mool/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/moo/mool/viewmodel/LoginViewModel.kt
@@ -16,6 +16,9 @@ class LoginViewModel(private val loginRepository: LoginRepository): ViewModel() 
     val loginSuccess = MutableLiveData<Boolean>()
     val loginFailedMessage = MutableLiveData<String?>()
 
+    val resetPasswordSuccess = MutableLiveData<Boolean>()
+    val resetPasswordFailedMessage = MutableLiveData<String?>()
+
     fun login(requestLogin: RequestLogin) {
         loginRepository.loginUser(requestLogin, object : LoginRepository.LoginCallBack {
             override fun onSuccess() {
@@ -37,6 +40,19 @@ class LoginViewModel(private val loginRepository: LoginRepository): ViewModel() 
             override fun onError(message: String?) {
                 loginSuccess.postValue(false)
                 loginFailedMessage.postValue(message)
+            }
+        })
+    }
+
+    fun resetPassword(email: String) {
+        loginRepository.resetPassword(email, object : LoginRepository.LoginCallBack {
+            override fun onSuccess() {
+                resetPasswordSuccess.postValue(true)
+            }
+
+            override fun onError(message: String?) {
+                resetPasswordSuccess.postValue(false)
+                resetPasswordFailedMessage.postValue(message)
             }
         })
     }


### PR DESCRIPTION
- [x] 비밀번호 초기화 서버와 연동하여 임시 비밀번호을 통하여 비밀번호 초기화 구현
- 비밀번호 초기화 버튼 클릭 후 메일 전송후 완료 팝업 사이의 딜레이 간의 중복 메일 전송을 막기 위하여 초기화 버튼 클릭 시 초기화 버튼 즉시 비활성화 처리
- [x] 일부 코드 수정 및 정리

resolved: #277