### PR TITLE
#317 [bug] Modify Delete Account Message

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -209,7 +209,7 @@
     <string name="setting_delete_account">탈퇴하기</string>
     <string name="setting_delete_account_complete">탈퇴완료</string>
     <string name="setting_logout_dialog_description">정말 로그아웃 하시겠어요?</string>
-    <string name="setting_delete_account_check_dialog_description">탈퇴 시 모든 활동정보가 삭제되며, 계정삭제 후 7일 간 다시 가입할 수 없어요...정말 탈퇴 하실건가요?</string>
+    <string name="setting_delete_account_check_dialog_description">탈퇴 시 모든 활동정보가 삭제돼요. 정말 탈퇴하실건가요?</string>
     <string name="setting_delete_account_complete_dialog_description">아직 무물은 당신에게 보여드리고 싶은 수많은 이야기들이 있습니다. 다시 돌아오길 기다리고 있을게요!</string>
     <string name="comment_update_title">수정하기</string>
     <string name="comment_update_confirm">등록</string>


### PR DESCRIPTION
- [x] 계정 삭제 시 안내 메시지 문구 변경
**변경 전:** 탈퇴 시 모든 활동정보가 삭제되며, 계정삭제 후 7일 간 다시 가입할 수 없어요...정말 탈퇴 하실건가요?
**변경 후:** 탈퇴 시 모든 활동정보가 삭제돼요. 정말 탈퇴하실건가요?

resolved: #317