### PR TITLE
#327 [bug] WriteFragment Server Error

### DIFF
--- a/app/src/main/java/com/moo/mool/view/write/WriteFragment.kt
+++ b/app/src/main/java/com/moo/mool/view/write/WriteFragment.kt
@@ -113,6 +113,7 @@ class WriteFragment : Fragment() {
                     mDialogView.findViewById<TextView>(R.id.tv_dialog_cancel).visibility = View.GONE
                     confirmButton.setOnClickListener {
                         mAlertDialog.dismiss()
+                        activeButtonSave()
                     }
                 }
             }


### PR DESCRIPTION
- [x] 글 작성 중, 서버 오류 발생으로 작성 미 완료 시, 버튼 비활성화로 인한 화면 이동 불가 버그
- 서버 오류 발생시, 비활성화된 버튼 다시 활성화 되도록 설정

resolved: #327