### PR TITLE
#331 [bug] Dialog Error about ChangeNickname, ResetPassword

### DIFF
--- a/app/src/main/java/com/moo/mool/view/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/moo/mool/view/profile/ProfileFragment.kt
@@ -149,8 +149,8 @@ class ProfileFragment : Fragment() {
                 mDialogView.findViewById<TextView>(R.id.tv_message_dialog_description)
                     .setText(R.string.profile_change_nickname_fail_dialog_description)
 
-                mDialogView.findViewById<ConstraintLayout>(R.id.tv_dialog_confirm).visibility = View.GONE
-                mDialogView.findViewById<ConstraintLayout>(R.id.tv_dialog_cancel).visibility = View.VISIBLE
+                mDialogView.findViewById<TextView>(R.id.tv_dialog_confirm).visibility = View.GONE
+                mDialogView.findViewById<TextView>(R.id.tv_dialog_cancel).visibility = View.VISIBLE
                 // Dialog 중복 실행 방지
                 if(mAlertDialog != null && !mAlertDialog.isShowing) {
                     mAlertDialog.show()

--- a/app/src/main/java/com/moo/mool/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/moo/mool/viewmodel/LoginViewModel.kt
@@ -22,10 +22,8 @@ class LoginViewModel @Inject constructor(
     val responseLogin = MutableLiveData<Boolean?>()
     val loginFailedMessage = MutableLiveData<String?>()
 
-    // private val _resetPasswordSuccess = MutableLiveData<Boolean?>(false)
-    // val resetPasswordSuccess = _resetPasswordSuccess.asStateFlow()
-    val resetPasswordSuccess = MutableLiveData<Boolean>()
-    val resetPasswordFailedMessage = MutableLiveData<String?>()
+    private val _resetPasswordSuccess = MutableStateFlow(false)
+    val resetPasswordSuccess = _resetPasswordSuccess.asStateFlow()
 
     private val _networkError = MutableStateFlow(false)
     val networkError = _networkError.asStateFlow()
@@ -53,12 +51,12 @@ class LoginViewModel @Inject constructor(
     }
 
     fun resetPassword(email: String) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(Dispatchers.Main) {
             runCatching {
                 loginRepository.resetPassword(email)
             }.getOrNull()?.let {
-                resetPasswordSuccess.postValue(true)
-            } ?: resetPasswordSuccess.postValue(false)
+                _resetPasswordSuccess.emit(false) // 별도의 응답이 오는 경우는, 오류메시지의 경우임
+            } ?: _resetPasswordSuccess.emit(true)
         }
     }
 }


### PR DESCRIPTION
- [x] 프로필 변경 Fragment에서, 닉네임 중복확인 시 Dialog가 정상적으로 나오지 않는 현상
- [x] 이메일 계정 로그인 화면에서, 비밀번호 초기화 메일 전송 Dialog가 정상적으로 나오지 않는 현상

resolved: #331